### PR TITLE
Allow custom vehicles to have presets and load the presets

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -175,8 +175,13 @@ function GetCurrentPreset()
 end
 
 function GetVehicleMan(vehicle)
-    return vehicle:Manufacturer():Type().value
+    if vehicle:Manufacturer():Type().value == "Invalid" then
+        return vehicle:GetID().value
+    else
+        return vehicle:Manufacturer():Type().value
+    end
 end
+
 function GetVehicleModel(vehicle)
     return vehicle:Model():Type().value
 end


### PR DESCRIPTION
When custom vehicle doesn't have a manufacture, the value returned by GetVehicleMan() function is "Invalid"

But any custom vehicle always have an ID, so let's use their ID as part of the identifier to save/load presets.