### PR TITLE
xMult Offset Slider with Weapon Handling

### DIFF
--- a/Modules/Config.lua
+++ b/Modules/Config.lua
@@ -1,12 +1,13 @@
 local Config = {
     ["data"] = {
         ["tiltMult"] = 1.150,
+        ["xMult"] = 0.0,
         ["yMult"] = 1.0,
         ["zMult"] = 0.5,
         ["fov"] = 60,
         ["sensitivity"] = 50,
         ["perCarPresets"] = {},
-        ["autoSetPerCar"] = true
+        ["autoSetPerCar"] = true,
     },
     ["isReady"] = false
 }
@@ -44,10 +45,16 @@ function Migrate()
     if Config.data.perCarPresets == nil then
         Config.data.perCarPresets = {}
     end
+    if Config.data.xMult == nil then
+        Config.data.xMult = 0.0
+    end
 
     for _, pr in pairs(Config.data.perCarPresets) do
         if pr.preset[5] == nil then
             pr.preset[5] = 50
+        end
+        if pr.preset[6] == nil then
+            pr.preset[6] = 0.0
         end
     end
 

--- a/init.lua
+++ b/init.lua
@@ -87,15 +87,17 @@ end
 function TiltCamera()
     Game.GetPlayer():GetFPPCameraComponent():SetLocalOrientation(Quaternion.new((-0.06 * Config.data.tiltMult), 0.0, 0.0, 1.0))
 end
+
 function ResetTilt()
     Game.GetPlayer():GetFPPCameraComponent():SetLocalOrientation(Quaternion.new(0.00, 0.0, 0.0, 1.0))
 end
 
 function RaiseCamera()
-    Game.GetPlayer():GetFPPCameraComponent():SetLocalPosition(Vector4.new(0.0, -(0.02 * Config.data.zMult), (0.09 * Config.data.yMult), 1.0))
+    Game.GetPlayer():GetFPPCameraComponent():SetLocalPosition(Vector4.new((0.02 * Config.data.xMult), -(0.02 * Config.data.zMult), (0.09 * Config.data.yMult), 1.0))
 end
+
 function ResetCamera()
-    Game.GetPlayer():GetFPPCameraComponent():SetLocalPosition(Vector4.new(0.0, 0, 0, 1.0))
+    Game.GetPlayer():GetFPPCameraComponent():SetLocalPosition(Vector4.new((0.02 * Config.data.xMult), 0, 0, 1.0))
 end
 
 function FlipY()
@@ -173,7 +175,7 @@ function IsPlayerDriver()
 end
 
 function GetCurrentPreset()
-    return { Config.data.tiltMult, Config.data.yMult, Config.data.zMult, Config.data.fov, Config.data.sensitivity}
+    return { Config.data.tiltMult, Config.data.yMult, Config.data.zMult, Config.data.fov, Config.data.sensitivity, Config.data.xMult }
 end
 
 function GetVehicleMan(vehicle)
@@ -361,7 +363,8 @@ function IsSamePreset(pr)
             math.abs(Config.data.yMult - pr[2]) < 0.01 and
             math.abs(Config.data.zMult - pr[3]) < 0.01 and
             math.abs(Config.data.fov - pr[4]) < 0.01 and
-            math.abs(Config.data.sensitivity - pr[5]) < 0.01
+            math.abs(Config.data.sensitivity - pr[5]) < 0.01 and
+            math.abs(Config.data.xMult - pr[6]) < 0.01
 end
 
 function DeletePreset(key)
@@ -374,6 +377,7 @@ function ApplyPreset(pr)
     Config.data.zMult = pr[3]
     Config.data.fov = pr[4]
     Config.data.sensitivity = pr[5]
+    Config.data.xMult = pr[6]
 end
 
 
@@ -537,6 +541,12 @@ function BetterVehicleFirstPerson:New()
             -- luacheck:ignore lowercase-global
             Config.data.tiltMult, isTiltChanged = ImGui.DragFloat(" Tilt Multiplier ", Config.data.tiltMult, 0.01, -1, 5)
             if isTiltChanged then
+                RefreshCameraIfNeeded()
+            end
+
+            -- Horizontal Offset control
+            Config.data.xMult, isXChanged = ImGui.DragFloat(" X Multiplier ", Config.data.xMult, 0.01, -2, 5)
+            if isXChanged then
                 RefreshCameraIfNeeded()
             end
 

--- a/init.lua
+++ b/init.lua
@@ -420,6 +420,14 @@ function BetterVehicleFirstPerson:New()
                     SetFOV() -- Weapon holstered: set FOV back to vehicle preset (also applies when choosing not to maintain FOV with weapon use)
                 end
             end
+
+            if isInVehicle then
+                if isWeaponDrawnNext and not wasWeaponDrawn then
+                    Game.GetPlayer():GetFPPCameraComponent():SetLocalPosition(Vector4.new(0, -(0.02 * Config.data.zMult), (0.09 * Config.data.yMult), 1.0))
+                elseif not isWeaponDrawnNext and wasWeaponDrawn then
+                    Game.GetPlayer():GetFPPCameraComponent():SetLocalPosition(Vector4.new((0.02 * Config.data.xMult), -(0.02 * Config.data.zMult), (0.09 * Config.data.yMult), 1.0))
+                end
+            end
             
             isInVehicle = isInVehicleNext
             wasWeaponDrawn = isWeaponDrawn -- Track last weapon state explicitly

--- a/init.lua
+++ b/init.lua
@@ -424,7 +424,7 @@ function BetterVehicleFirstPerson:New()
             isInVehicle = isInVehicleNext
             wasWeaponDrawn = isWeaponDrawn -- Track last weapon state explicitly
             isWeaponDrawn = isWeaponDrawnNext
-        end)
+        end, {})
 
         Observe('hudCarController', 'RegisterToVehicle', function(_, registered)
             if not registered then


### PR DESCRIPTION
This PR introduces a x-offset slider for improved compatibility with certain modded vehicles that do not have a centered viewport. 

![F40-X](https://github.com/user-attachments/assets/bd1a9039-3c83-4b43-ab17-171a9f93e513)

Below is a summary of the changes:

### Key Changes:
1. **Horizontal Offset (`xMult`) Support**:
   - Added `xMult` to presets for horizontal camera adjustments.
   - Updated functions like `RaiseCamera`, `ResetCamera`, and `GetCurrentPreset` to include `xMult`.

2. **Preset Management**:
   - Improved preset structure to include `xMult`.
   - Updated `IsSamePreset` and `ApplyPreset` to handle the new preset format.

3. **Camera Position Adjustments**:
   - Enhanced camera positioning logic to support horizontal offsets.

4. **Weapon Handling**:
   - Adjusted camera behavior when weapons are drawn or holstered in vehicles to exclude xMult.

5. **UI**:
   - Added UI controls for `xMult` in the ImGui interface.

---

### Testing:
- Verified all features, including camera adjustments, preset management, and weapon handling.
- Tested compatibility with various vehicles and scenarios.
- Ensured the new UI slider is functional.

---

### Use with weapon (F40);

![F40-X-Weapon](https://github.com/user-attachments/assets/0fb8be90-74c6-4f56-93f9-3a8d287f1723)
